### PR TITLE
add default model setting for basic commands

### DIFF
--- a/src/Ollama.ts
+++ b/src/Ollama.ts
@@ -31,7 +31,7 @@ export class Ollama extends Plugin {
             url: `${this.settings.ollamaUrl}/api/generate`,
             body: JSON.stringify({
               prompt: command.prompt + "\n\n" + text,
-              model: command.model,
+              model: command.model || this.settings.defaultModel,
               options: {
                 temperature: command.temperature || 0.2,
               },

--- a/src/OllamaSettingTab.ts
+++ b/src/OllamaSettingTab.ts
@@ -29,6 +29,19 @@ export class OllamaSettingTab extends PluginSettingTab {
           })
       );
 
+    new Setting(containerEl)
+      .setName("default model")
+      .setDesc("Name of the default ollama model to use for prompts")
+      .addText((text) =>
+        text
+          .setPlaceholder("llama2")
+          .setValue(this.plugin.settings.defaultModel)
+          .onChange(async (value) => {
+            this.plugin.settings.defaultModel = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
     containerEl.createEl("h3", { text: "Commands" });
 
     const newCommand: OllamaCommand = {

--- a/src/data/defaultSettings.ts
+++ b/src/data/defaultSettings.ts
@@ -2,54 +2,47 @@ import { OllamaSettings } from "model/OllamaSettings";
 
 export const DEFAULT_SETTINGS: OllamaSettings = {
   ollamaUrl: "http://localhost:11434",
+  defaultModel: "llama2",
   commands: [
     {
       name: "Summarize selection",
       prompt:
         "Act as a writer. Summarize the text in a view sentences highlighting the key takeaways. Output only the text and nothing else, do not chat, no preamble, get to the point.",
-      model: "llama2",
     },
     {
       name: "Explain selection",
       prompt:
         "Act as a writer. Explain the text in simple and concise terms keeping the same meaning. Output only the text and nothing else, do not chat, no preamble, get to the point.",
-      model: "llama2",
     },
     {
       name: "Expand selection",
       prompt:
         "Act as a writer. Expand the text by adding more details while keeping the same meaning. Output only the text and nothing else, do not chat, no preamble, get to the point.",
-      model: "llama2",
     },
     {
       name: "Rewrite selection (formal)",
       prompt:
         "Act as a writer. Rewrite the text in a more formal style while keeping the same meaning. Output only the text and nothing else, do not chat, no preamble, get to the point.",
-      model: "llama2",
     },
     {
       name: "Rewrite selection (casual)",
       prompt:
         "Act as a writer. Rewrite the text in a more casual style while keeping the same meaning. Output only the text and nothing else, do not chat, no preamble, get to the point.",
-      model: "llama2",
     },
     {
       name: "Rewrite selection (active voice)",
       prompt:
         "Act as a writer. Rewrite the text in with an active voice while keeping the same meaning. Output only the text and nothing else, do not chat, no preamble, get to the point.",
-      model: "llama2",
     },
     {
       name: "Rewrite selection (bullet points)",
       prompt:
         "Act as a writer. Rewrite the text into bullet points while keeping the same meaning. Output only the text and nothing else, do not chat, no preamble, get to the point.",
-      model: "llama2",
     },
     {
       name: "Caption selection",
       prompt:
         "Act as a writer. Create only one single heading for the whole text that is giving a good understanding of what the reader can expect. Output only the caption and nothing else, do not chat, no preamble, get to the point. Your format should be ## Caption.",
-      model: "llama2",
     },
   ],
 };

--- a/src/model/OllamaCommand.ts
+++ b/src/model/OllamaCommand.ts
@@ -1,6 +1,6 @@
 export interface OllamaCommand {
   name: string;
   prompt: string;
-  model: string;
+  model?: string;
   temperature?: number;
 }

--- a/src/model/OllamaSettings.ts
+++ b/src/model/OllamaSettings.ts
@@ -2,5 +2,6 @@ import { OllamaCommand } from "model/OllamaCommand";
 
 export interface OllamaSettings {
   ollamaUrl: string;
+  defaultModel: string;
   commands: OllamaCommand[];
 }


### PR DESCRIPTION
I use other models.

I didn't want te redefine your original commands since they were great.

It looks like this
<img width="778" alt="Screenshot 2023-11-02 at 4 39 45 PM" src="https://github.com/hinterdupfinger/obsidian-ollama/assets/22123928/a8810f4a-e3bf-4643-9a56-5dcb16d4cdd8">
