### PR TITLE
Ollama Streaming

### DIFF
--- a/src/Ollama.ts
+++ b/src/Ollama.ts
@@ -1,5 +1,5 @@
 import { kebabCase } from "service/kebabCase";
-import { Editor, Notice, Plugin, requestUrl } from "obsidian";
+import { Editor, Notice, Plugin } from "obsidian";
 import { OllamaSettingTab } from "OllamaSettingTab";
 import { DEFAULT_SETTINGS } from "data/defaultSettings";
 import { OllamaSettings } from "model/OllamaSettings";
@@ -22,53 +22,86 @@ export class Ollama extends Plugin {
           const selection = editor.getSelection();
           const text = selection ? selection : editor.getValue();
 
-          const cursorPosition = editor.getCursor();
-
-          editor.replaceRange("✍️", cursorPosition);
-
-          requestUrl({
+          fetch(`${this.settings.ollamaUrl}/api/generate`, {
             method: "POST",
-            url: `${this.settings.ollamaUrl}/api/generate`,
+            headers: {
+              'Content-Type': 'application/json'
+            },
             body: JSON.stringify({
               prompt: command.prompt + "\n\n" + text,
               model: command.model || this.settings.defaultModel,
               options: {
                 temperature: command.temperature || 0.2,
               },
+              stream: true, // Enable streaming responses
             }),
           })
-            .then((response) => {
-              const steps = response.text
-                .split("\n")
-                .filter((step) => step && step.length > 0)
-                .map((step) => JSON.parse(step));
+            .then(response => {
+              if (!response.body) {
+                throw new Error('ReadableStream not yet supported in this browser.');
+              }
+              const reader = response.body.getReader();
+              let decoder = new TextDecoder();
+              let contentBuffer = '';
 
-              editor.replaceRange(
-                steps
-                  .map((step) => step.response)
-                  .join("")
-                  .trim(),
-                cursorPosition,
-                {
-                  ch: cursorPosition.ch + 1,
-                  line: cursorPosition.line,
-                }
-              );
-            })
-            .catch((error) => {
-              new Notice(`Error while generating text: ${error.message}`);
-              editor.replaceRange("", cursorPosition, {
-                ch: cursorPosition.ch + 1,
-                line: cursorPosition.line,
-              });
-            });
+              function read() {
+                reader.read().then(({ done, value }) => {
+                  if (done) {
+                    // This is the end of the stream
+                    if (contentBuffer.trim() !== "") {
+                      insertContentAtEnd(contentBuffer);
+                    }
+                    return;
+                  }
+                  const chunk = decoder.decode(value, { stream: true });
+                  contentBuffer += chunk;
+
+                  let pos;
+                  while ((pos = contentBuffer.indexOf('\n')) >= 0) {
+                    let line = contentBuffer.slice(0, pos);
+                    contentBuffer = contentBuffer.slice(pos + 1);
+
+                    try {
+                      let responseObj = JSON.parse(line);
+                      if (!responseObj.done) {
+                        insertContentAtEnd(responseObj.response);
+                      } else {
+                        // Final object with 'done' true
+                        insertContentAtEnd(responseObj.response);
+                        return;
+                      }
+                    } catch (e) {
+                      console.error('Error parsing JSON:', e);
+                    }
+                  }
+                  read(); // Read the next chunk
+                }).catch(error => {
+                  console.error('Error while reading the stream', error);
+                  new Notice(`Error while generating text: ${error.message}`);
+                });
+              }
+              function insertContentAtEnd(text: string) {
+                // Move the cursor to the end of the editor content
+                let lastLine = editor.lineCount() - 1;
+                let lastLineLength = editor.getLine(lastLine).length;
+                let endCursorPos = { line: lastLine, ch: lastLineLength };
+
+                // Insert the content at the end of the editor content
+                editor.replaceRange(text, endCursorPos);
+
+                // No need to update cursor position since we're always appending at the end
+              }
+              read(); // Start reading the stream
+            }).catch(error => {
+            console.error('Error in fetch request:', error);
+            new Notice(`Error while generating text: ${error.message}. Is Ollama running?`);
+          });
+
         },
       });
     });
   }
-
   onunload() {}
-
   async loadSettings() {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
   }

--- a/src/Ollama.ts
+++ b/src/Ollama.ts
@@ -1,5 +1,5 @@
 import { kebabCase } from "service/kebabCase";
-import { Editor, Notice, Plugin } from "obsidian";
+import {Editor, Notice, Plugin, requestUrl} from "obsidian";
 import { OllamaSettingTab } from "OllamaSettingTab";
 import { DEFAULT_SETTINGS } from "data/defaultSettings";
 import { OllamaSettings } from "model/OllamaSettings";
@@ -9,7 +9,8 @@ export class Ollama extends Plugin {
 
   async onload() {
     await this.loadSettings();
-    this.addPromptCommands();
+
+    this.settings.stream ? this.addPromptCommandsStream() : this.addPromptCommands();
     this.addSettingTab(new OllamaSettingTab(this.app, this));
   }
 
@@ -21,6 +22,78 @@ export class Ollama extends Plugin {
         editorCallback: (editor: Editor) => {
           const selection = editor.getSelection();
           const text = selection ? selection : editor.getValue();
+
+          const cursorPosition = editor.getCursor();
+
+          editor.replaceRange("✍️", cursorPosition);
+
+          requestUrl({
+            method: "POST",
+            url: `${this.settings.ollamaUrl}/api/generate`,
+            body: JSON.stringify({
+              prompt: command.prompt + "\n\n" + text,
+              model: command.model || this.settings.defaultModel,
+              options: {
+                temperature: command.temperature || 0.2,
+              },
+            }),
+          })
+            .then((response) => {
+              const steps = response.text
+                .split("\n")
+                .filter((step) => step && step.length > 0)
+                .map((step) => JSON.parse(step));
+
+              editor.replaceRange(
+                steps
+                  .map((step) => step.response)
+                  .join("")
+                  .trim(),
+                cursorPosition,
+                {
+                  ch: cursorPosition.ch + 1,
+                  line: cursorPosition.line,
+                }
+              );
+            })
+            .catch((error) => {
+              new Notice(`Error while generating text: ${error.message}`);
+              editor.replaceRange("", cursorPosition, {
+                ch: cursorPosition.ch + 1,
+                line: cursorPosition.line,
+              });
+            });
+        },
+      });
+    });
+  }
+
+  private addPromptCommandsStream() {
+
+    this.settings.commands.forEach((command) => {
+      this.addCommand({
+        id: kebabCase(command.name),
+        name: command.name,
+        editorCallback: (editor: Editor) => {
+
+          let reader: ReadableStreamDefaultReader;
+          const onKeyDown = () => {
+            console.log("Key pressed")
+            reader.cancel();
+            document.removeEventListener('keydown', onKeyDown); // remove the event listener
+            new Notice('Ollama: Stream cancelled by user');
+            //set cursor to end of editor
+            const lastLine = editor.lineCount() - 1;
+            const lastLineLength = editor.getLine(lastLine).length;
+            const endCursorPos = { line: lastLine, ch: lastLineLength };
+            editor.setCursor(endCursorPos);
+          };
+
+          const selection = editor.getSelection();
+          const text = selection ? selection : editor.getValue();
+          const cursorPosition = editor.getCursor();
+
+          editor.replaceRange("⏳", cursorPosition);
 
           fetch(`${this.settings.ollamaUrl}/api/generate`, {
             method: "POST",
@@ -37,12 +110,21 @@ export class Ollama extends Plugin {
             }),
           })
             .then(response => {
+              // Listen for the Escape key
+              document.addEventListener('keydown', onKeyDown);
+
               if (!response.body) {
                 throw new Error('ReadableStream not yet supported in this browser.');
               }
-              const reader = response.body.getReader();
-              let decoder = new TextDecoder();
+              reader = response.body.getReader();
+              const decoder = new TextDecoder();
               let contentBuffer = '';
+
+              //remove the ⏳
+                editor.replaceRange("", cursorPosition, {
+                    ch: cursorPosition.ch + 1,
+                    line: cursorPosition.line,
+                });
 
               function read() {
                 reader.read().then(({ done, value }) => {
@@ -53,21 +135,24 @@ export class Ollama extends Plugin {
                     }
                     return;
                   }
+
                   const chunk = decoder.decode(value, { stream: true });
                   contentBuffer += chunk;
 
-                  let pos;
+                  let pos; // Position of the newline
                   while ((pos = contentBuffer.indexOf('\n')) >= 0) {
-                    let line = contentBuffer.slice(0, pos);
+                    const line = contentBuffer.slice(0, pos);
                     contentBuffer = contentBuffer.slice(pos + 1);
 
                     try {
-                      let responseObj = JSON.parse(line);
+                      const responseObj = JSON.parse(line);
                       if (!responseObj.done) {
+
                         insertContentAtEnd(responseObj.response);
                       } else {
                         // Final object with 'done' true
                         insertContentAtEnd(responseObj.response);
+                        document.removeEventListener('keydown', onKeyDown); // remove the event listener
                         return;
                       }
                     } catch (e) {
@@ -78,18 +163,20 @@ export class Ollama extends Plugin {
                 }).catch(error => {
                   console.error('Error while reading the stream', error);
                   new Notice(`Error while generating text: ${error.message}`);
-                });
+                })
               }
               function insertContentAtEnd(text: string) {
                 // Move the cursor to the end of the editor content
-                let lastLine = editor.lineCount() - 1;
-                let lastLineLength = editor.getLine(lastLine).length;
-                let endCursorPos = { line: lastLine, ch: lastLineLength };
+                const lastLine = editor.lineCount() - 1;
+                const lastLineLength = editor.getLine(lastLine).length;
+                const endCursorPos = { line: lastLine, ch: lastLineLength };
 
                 // Insert the content at the end of the editor content
                 editor.replaceRange(text, endCursorPos);
 
-                // No need to update cursor position since we're always appending at the end
+                // Move the cursor to the end of the editor content
+                editor.setCursor(endCursorPos);
+
               }
               read(); // Start reading the stream
             }).catch(error => {

--- a/src/OllamaSettingTab.ts
+++ b/src/OllamaSettingTab.ts
@@ -30,6 +30,19 @@ export class OllamaSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+        .setName("Stream")
+        .setDesc("Stream the output of the Ollama server.")
+        .addToggle((toggle) =>
+            toggle
+                .setValue(this.plugin.settings.stream)
+                  .onChange(async (value) => {
+                    this.plugin.settings.stream = value;
+                    await this.plugin.saveSettings();
+                  }
+                )
+        );
+
+    new Setting(containerEl)
       .setName("default model")
       .setDesc("Name of the default ollama model to use for prompts")
       .addText((text) =>

--- a/src/data/defaultSettings.ts
+++ b/src/data/defaultSettings.ts
@@ -2,6 +2,7 @@ import { OllamaSettings } from "model/OllamaSettings";
 
 export const DEFAULT_SETTINGS: OllamaSettings = {
   ollamaUrl: "http://localhost:11434",
+  stream: false,
   defaultModel: "llama2",
   commands: [
     {

--- a/src/model/OllamaSettings.ts
+++ b/src/model/OllamaSettings.ts
@@ -2,6 +2,7 @@ import { OllamaCommand } from "model/OllamaCommand";
 
 export interface OllamaSettings {
   ollamaUrl: string;
+  stream: boolean;
   defaultModel: string;
   commands: OllamaCommand[];
 }


### PR DESCRIPTION
~~**WORK IN PROGRESS**~~

Referencing: https://github.com/hinterdupfinger/obsidian-ollama/issues/9


I got a working version for my feature request. Since I had to use the fetch API instead of Obsidian's in-build requestUrl() function, it doesn't work right out of the box - since CORS comes into play. 

To handle the CORS error,  you have to set the origins env var for your Ollama instance like this:

`OLLAMA_ORIGINS=http://192.168.1.1:*,app://obsidian.md* ollama run xwinlm
`
as described [here](https://github.com/jmorganca/ollama/blob/main/docs/faq.md#how-can-i-allow-additional-web-origins-to-access-ollama).

If anyone has an idea how to make this more elegant, feel free to contribute.

Suggestions:
- Since this requires some extra steps to get it to work, namely running Ollama with an env variable, maybe add a settings toggle to opt-in to use this feature. 


Here's a preview:

![Bildschirmaufnahme 2023-11-05 um 17 43 36 (1)](https://github.com/hinterdupfinger/obsidian-ollama/assets/10332147/db9c03d2-a139-450e-b97c-4a8ed2169bf7)
