### PR TITLE
Fix typo: "a view sentences" -> "a few sentences"

### DIFF
--- a/src/data/defaultSettings.ts
+++ b/src/data/defaultSettings.ts
@@ -7,7 +7,7 @@ export const DEFAULT_SETTINGS: OllamaSettings = {
     {
       name: "Summarize selection",
       prompt:
-        "Act as a writer. Summarize the text in a view sentences highlighting the key takeaways. Output only the text and nothing else, do not chat, no preamble, get to the point.",
+        "Act as a writer. Summarize the text in a few sentences highlighting the key takeaways. Output only the text and nothing else, do not chat, no preamble, get to the point.",
     },
     {
       name: "Explain selection",


### PR DESCRIPTION
Fixes this tiny typo. As reported in #11, fixes #11