### PR TITLE
Add Link Context for Model Inference

### DIFF
--- a/src/Ollama.ts
+++ b/src/Ollama.ts
@@ -1,5 +1,5 @@
 import { kebabCase } from "service/kebabCase";
-import { Editor, Notice, Plugin, requestUrl } from "obsidian";
+import { Editor, Notice, Plugin, requestUrl, MarkdownView, MarkdownRenderer } from "obsidian";
 import { OllamaSettingTab } from "OllamaSettingTab";
 import { DEFAULT_SETTINGS } from "data/defaultSettings";
 import { OllamaSettings } from "model/OllamaSettings";
@@ -18,13 +18,66 @@ export class Ollama extends Plugin {
       this.addCommand({
         id: kebabCase(command.name),
         name: command.name,
-        editorCallback: (editor: Editor) => {
+        editorCallback: async (editor: Editor, ctx: MarkdownView) => {
           const selection = editor.getSelection();
           const text = selection ? selection : editor.getValue();
+          var context: any[] = [];
 
           const cursorPosition = editor.getCursor();
 
           editor.replaceRange("✍️", cursorPosition);
+
+          if (this.settings.contextLocalLinks || this.settings.contextRemoteLinks) {
+            const readFile = async (path: string): Promise<string> => {
+              var text: string = "";
+              var files = this.app.vault.getFiles();
+              for (let i = 0; i < files.length; i++ ) {
+                const file = files[i];
+                if (file?.basename == path) {
+                  text = await this.app.vault.read(file);
+                }
+              };
+              return text;
+            }
+            var contextText: string[] = [];
+            var doc = document.createElement("html");
+            await MarkdownRenderer.render(this.app, text, doc, ".", ctx);
+            var links = doc.querySelectorAll('a');
+            for (let i = 0; i <  links.length; i++) {
+              const link = links[i];
+              if (link.href.startsWith("http") && this.settings.contextRemoteLinks) {
+                // fetch the remote url and append the text to contextText
+                var response = await requestUrl({method: "GET", url: link.href});
+                contextText.push(response.text);
+              } else if (link.href.startsWith("app://obsidian.md/") && this.settings.contextLocalLinks) {
+                // read the local file and append the text to contextText
+                var path = link.href.replace("app://obsidian.md/", "");                
+                contextText.push(await readFile(path));
+              }
+            };
+
+            for (let i = 0; i < contextText.length; i++) {
+              var ctxtext = contextText[i];
+              // request the ollama server to generate a summary of the text
+              var response = await requestUrl({
+                method: "POST",
+                url: `${this.settings.ollamaUrl}/api/generate`,
+                body: JSON.stringify({
+                  prompt: this.settings.defaultContextPrompt + "\n\n" + ctxtext,
+                  model: command.model || this.settings.defaultModel,
+                  context: context,
+                  options: {
+                    temperature: command.temperature || 0.2,
+                  },
+                }),
+              });
+              const steps = response.text
+                .split("\n")
+                .filter((step) => step && step.length > 0)
+                .map((step) => JSON.parse(step));
+              context = steps[steps.length - 1].context;
+            };
+          }
 
           requestUrl({
             method: "POST",
@@ -32,6 +85,7 @@ export class Ollama extends Plugin {
             body: JSON.stringify({
               prompt: command.prompt + "\n\n" + text,
               model: command.model || this.settings.defaultModel,
+              context: context,
               options: {
                 temperature: command.temperature || 0.2,
               },

--- a/src/OllamaSettingTab.ts
+++ b/src/OllamaSettingTab.ts
@@ -42,6 +42,43 @@ export class OllamaSettingTab extends PluginSettingTab {
           })
       );
 
+    new Setting(containerEl)
+      .setName("context local links")
+      .setDesc("Use local links as context for the model")
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.contextLocalLinks)
+          .onChange(async (value) => {
+            this.plugin.settings.contextLocalLinks = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("context remote links")
+      .setDesc("Use remote links as context for the model")
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.contextRemoteLinks)
+          .onChange(async (value) => {
+            this.plugin.settings.contextRemoteLinks = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+      new Setting(containerEl)
+      .setName("context prompt")
+      .setDesc("Prompt used to build context from links")
+      .addText((text) =>
+        text
+          .setPlaceholder("Act as a writer. Summarize the text in a view sentences highlighting the key takeaways. Output only the text and nothing else, do not chat, no preamble, get to the point.")
+          .setValue(this.plugin.settings.defaultContextPrompt)
+          .onChange(async (value) => {
+            this.plugin.settings.defaultContextPrompt = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
     containerEl.createEl("h3", { text: "Commands" });
 
     const newCommand: OllamaCommand = {

--- a/src/data/defaultSettings.ts
+++ b/src/data/defaultSettings.ts
@@ -3,6 +3,9 @@ import { OllamaSettings } from "model/OllamaSettings";
 export const DEFAULT_SETTINGS: OllamaSettings = {
   ollamaUrl: "http://localhost:11434",
   defaultModel: "llama2",
+  contextLocalLinks: true,
+  contextRemoteLinks: false,
+  defaultContextPrompt: "Act as a writer. Summarize the text in a view sentences highlighting the key takeaways. Output only the text and nothing else, do not chat, no preamble, get to the point.",
   commands: [
     {
       name: "Summarize selection",

--- a/src/model/OllamaSettings.ts
+++ b/src/model/OllamaSettings.ts
@@ -4,4 +4,7 @@ export interface OllamaSettings {
   ollamaUrl: string;
   defaultModel: string;
   commands: OllamaCommand[];
+  contextLocalLinks: boolean;
+  contextRemoteLinks: boolean;
+  defaultContextPrompt: string;
 }


### PR DESCRIPTION
This adds links as context for the ollama API. This isn't great and there's a lot of await async references... but it's a start.

The idea is to use the content of links in the text as context to the conversational style of interacting with Llama2.